### PR TITLE
Fix version conflicts caused by PR#139

### DIFF
--- a/src/SocialQ.Android/SocialQ.Android.csproj
+++ b/src/SocialQ.Android/SocialQ.Android.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Shiny.Core" Version="1.2.0.1755" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
-    <PackageReference Include="ReactiveUI.XamForms" Version="13.1.1" />
+    <PackageReference Include="ReactiveUI.XamForms" Version="14.1.1" />
     <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.10" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Include="Xamarin.Forms.Auth" Version="2.0.16" />

--- a/src/SocialQ.Forms/SocialQ.Forms.csproj
+++ b/src/SocialQ.Forms/SocialQ.Forms.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="Pharmacist.Common" Version="2.*" />
     <PackageReference Include="Pharmacist.MsBuild" Version="2.*" PrivateAssets="all" />
-    <PackageReference Include="ReactiveUI.XamForms" Version="13.1.1" />
+    <PackageReference Include="ReactiveUI.XamForms" Version="14.1.1" />
     <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.10" />
     <PackageReference Include="Sextant.Plugins.Popup" Version="2.11.1" />
     <PackageReference Include="Sextant.XamForms" Version="2.11.1" />
@@ -31,7 +31,7 @@
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
     <PackageReference Include="Xamarin.Forms.PancakeView" Version="2.3.0.759" />
     <PackageReference Include="XF.Material" Version="1.7.7" />
-    <PackageReference Include="Xamarin.Forms" Version="4.8.0.1821" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SocialQ.iOS/SocialQ.iOS.csproj
+++ b/src/SocialQ.iOS/SocialQ.iOS.csproj
@@ -130,7 +130,7 @@
     <PackageReference Include="Shiny.Core" Version="1.2.0.1755" />
     <PackageReference Include="SkiaSharp" Version="2.80.2" />
     <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
-    <PackageReference Include="ReactiveUI.XamForms" Version="13.1.1" />
+    <PackageReference Include="ReactiveUI.XamForms" Version="14.1.1" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SocialQ/SocialQ.csproj
+++ b/src/SocialQ/SocialQ.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,16 +7,16 @@
 
     <ItemGroup>
       <PackageReference Include="akavache" Version="7.2.1" />
-      <PackageReference Include="DynamicData" Version="7.1.1" />
+      <PackageReference Include="DynamicData" Version="7.1.17" />
       <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.7" />
       <PackageReference Include="LanguageExt.Core" Version="3.4.15" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
       <PackageReference Include="ReactiveMarbles.PropertyChanged" Version="1.4.1" />
-      <PackageReference Include="ReactiveUI" Version="13.1.1" />
-      <PackageReference Include="ReactiveUI.Fody" Version="13.1.1" />
-      <PackageReference Include="ReactiveUI.XamForms" Version="13.1.1" />
-      <PackageReference Include="Xamarin.Forms" Version="4.8.0.1821" />
+      <PackageReference Include="ReactiveUI" Version="14.1.1" />
+      <PackageReference Include="ReactiveUI.Fody" Version="14.1.1" />
+      <PackageReference Include="ReactiveUI.XamForms" Version="14.1.1" />
+      <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
       <PackageReference Include="refit" Version="6.0.38" />
       <PackageReference Include="Rg.Plugins.Popup" Version="2.0.0.10" />
       <PackageReference Include="Sextant.Plugins.Popup" Version="2.11.1" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump ReactiveUI.XamForms from 13.1.1 to 14.1.1. [(PR#139)](https://github.com/reactivemarbles/SocialQ/pull/139).
Hope this fix can help you.

Best regards,
sucrose